### PR TITLE
Removed #response from Net::HTTP::Response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ rvm:
   - rbx-2.1.1
 matrix:
   allow_failures:
-    - rvm: jruby-1.7.9
+    - jruby: jruby-1.7.9
+    - rbx: rbx-2.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ rvm:
   - rbx-2.1.1
 matrix:
   allow_failures:
-    - jruby: jruby-1.7.9
-    - rbx: rbx-2.1.1
+    - rvm: rbx-2.1.1

--- a/lib/artoo-spark/version.rb
+++ b/lib/artoo-spark/version.rb
@@ -1,5 +1,5 @@
 module Artoo
   module Spark
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/lib/artoo/adaptors/spark.rb
+++ b/lib/artoo/adaptors/spark.rb
@@ -42,7 +42,7 @@ module Artoo
         url = device_url + "/digitalread"
         post(url, {:params => pin})
       end
-      
+
       # GPIO - analog
       def analog_write(pin, level)
         url = device_url + "/analogwrite"
@@ -66,7 +66,7 @@ module Artoo
 
       def post(url, data={})
         data[:access_token] = access_token
-        HTTP.post(url, :form => data).response
+        HTTP.post(url, :form => data)
       end
 
       def device_url


### PR DESCRIPTION
This commit removes the `response` method for the Net::HTTP::Response.
The response method was (likely) deprecated in a Net::HTTP update.

Unfortunately, no unit tests were written for this change. The reason
being that the `WebMock` library would be required to stub a response.

Signed-off-by: Hector Rios that.hector@gmail.com
